### PR TITLE
Skip group 1 when changing spot for some tilesets

### DIFF
--- a/Assets/Content/Code/Area/Editor/AreaSceneSpotInfo.cs
+++ b/Assets/Content/Code/Area/Editor/AreaSceneSpotInfo.cs
@@ -228,7 +228,7 @@ namespace Area
 
         public static readonly Dictionary<int, HashSet<int>> UnfinishedTiles = new Dictionary<int, HashSet<int>> ()
         {
-            [10] = new HashSet<int> ()
+            [AreaTilesetHelper.idOfFallback] = new HashSet<int> ()
             {
                 TilesetUtility.configurationFloor << 8 | 1,
             },

--- a/Assets/Content/Code/Area/Editor/AreaSceneSpotInfo.cs
+++ b/Assets/Content/Code/Area/Editor/AreaSceneSpotInfo.cs
@@ -145,6 +145,10 @@ namespace Area
             var identifiersPresent = tileset.groupIdentifiers != null;
             foreach (var kvp in definition.subtypeGroups)
             {
+                if (UnfinishedTiles.TryGetValue (tileset.id, out var matches) && matches.Contains (configuration << 8 | kvp.Key))
+                {
+                    continue;
+                }
                 BuildGroupSubtypeInfo (tileset, identifiersPresent, kvp.Key, kvp.Value);
             }
 
@@ -221,5 +225,21 @@ namespace Area
         readonly StringBuilder lastSpotInfoBuilder = new StringBuilder ();
         int lastSpotGroup;
         int lastSpotSubtype;
+
+        public static readonly Dictionary<int, HashSet<int>> UnfinishedTiles = new Dictionary<int, HashSet<int>> ()
+        {
+            [10] = new HashSet<int> ()
+            {
+                TilesetUtility.configurationFloor << 8 | 1,
+            },
+            [30] = new HashSet<int> ()
+            {
+                TilesetUtility.configurationFloor << 8 | 1,
+            },
+            [50] = new HashSet<int> ()
+            {
+                TilesetUtility.configurationFloor << 8 | 1,
+            },
+        };
     }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
There are unfinished tiles in some tilesets. These tiles shouldn't be used with some configurations.

This is a temporary workaround. The proper solution would be to add a new field to AreaTilesetDatabaseSerialized to record which configurations have unfinished groups.


### Related Issues
- Resolves #001
<!-- List any other related issues here -->

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
