### PR TITLE
Refactor prop mode panel

### DIFF
--- a/Assets/Content/Code/Area/Editor/AreaOdinDrawers.cs
+++ b/Assets/Content/Code/Area/Editor/AreaOdinDrawers.cs
@@ -165,8 +165,8 @@ namespace Area
                 var style = k == firstButton
                     ? SirenixGUIStyles.MiniButtonLeft
                     : k == lastButton
-                            ? SirenixGUIStyles.MiniButtonRight
-                            : SirenixGUIStyles.MiniButtonMid;
+                        ? SirenixGUIStyles.MiniButtonRight
+                        : SirenixGUIStyles.MiniButtonMid;
                 var bg = GUI.backgroundColor;
                 if (k == value)
                 {
@@ -188,8 +188,8 @@ namespace Area
             [(int)AreaManager.EditingVolumeBrush.Square3x3] = "3x3R",
             [(int)AreaManager.EditingVolumeBrush.Circle] = "3x3C",
         };
-        static readonly List<int> labelMapKeys = labelMap.Keys.OrderBy (k => k).ToList();
-        static readonly int firstButton = labelMapKeys.First();
+        static readonly List<int> labelMapKeys = labelMap.Keys.OrderBy (k => k).ToList ();
+        static readonly int firstButton = labelMapKeys.First ();
         static readonly int lastButton = labelMapKeys.Last ();
     }
 
@@ -230,8 +230,8 @@ namespace Area
             [(int)AreaManager.RoadSubtype.ConcreteCurb] = "C+C",
             [(int)AreaManager.RoadSubtype.TileCurb] = "T+C",
         };
-        static readonly List<int> labelMapKeys = labelMap.Keys.OrderBy (k => k).ToList();
-        static readonly int firstButton = labelMapKeys.First();
+        static readonly List<int> labelMapKeys = labelMap.Keys.OrderBy (k => k).ToList ();
+        static readonly int firstButton = labelMapKeys.First ();
         static readonly int lastButton = labelMapKeys.Last ();
     }
 
@@ -410,9 +410,9 @@ namespace Area
 
             var v = ValueEntry.SmartValue;
             var rects = CalcRects (rectControl);
-            var x = DrawIntField(rects[0], rects[1], fieldLabels[0], v.x, enabledX);
-            var z = DrawIntField(rects[2], rects[3], fieldLabels[1], v.z, enabledZ);
-            var y = DrawIntField(rects[4], rects[5], fieldLabels[2], v.y, enabledY);
+            var x = DrawIntField (rects[0], rects[1], fieldLabels[0], v.x, enabledX);
+            var z = DrawIntField (rects[2], rects[3], fieldLabels[1], v.z, enabledZ);
+            var y = DrawIntField (rects[4], rects[5], fieldLabels[2], v.y, enabledY);
             if (x == v.x && z == v.z && y == v.y)
             {
                 return;
@@ -711,6 +711,51 @@ namespace Area
             {
                 Property.Children[i].Draw ();
             }
+            GUILayout.EndVertical ();
+        }
+    }
+
+    sealed class PropModeSelectedPropsDrawer : OdinValueDrawer<PropModeSelectedProps>
+    {
+        protected override void DrawPropertyLayout (GUIContent label)
+        {
+            var child = Property.Children[0];
+            for (var i = 0; i < child.Children.Count; i += 1)
+            {
+                var grandchild = child.Children[i];
+                if (grandchild.ValueEntry.WeakSmartValue == null)
+                {
+                    continue;
+                }
+                var entry = (PropModePanelEntry)grandchild.ValueEntry.WeakSmartValue;
+                if (!entry.isSelected)
+                {
+                    grandchild.Draw ();
+                    continue;
+                }
+                var colorPrevious = GUI.backgroundColor;
+                GUI.backgroundColor = Color.Lerp (GUI.backgroundColor, Color.cyan, 0.35f);
+                grandchild.Draw ();
+                GUI.backgroundColor = colorPrevious;
+            }
+        }
+    }
+
+    sealed class RightFoldoutGroupAttributeDrawer : OdinGroupDrawer<RightFoldoutGroupAttribute>
+    {
+        protected override void DrawPropertyLayout (GUIContent label)
+        {
+            GUILayout.BeginVertical ("Box");
+            var width = label != null ? SirenixGUIStyles.RightAlignedWhiteMiniLabel.CalcSize (label).x + 20f : 100f;
+            Property.State.Expanded = UtilityCustomInspector.DrawFoldout (Attribute.Title, Property.State.Expanded, GUILayoutOptions.MinWidth (width).ExpandWidth ());
+            if (SirenixEditorGUI.BeginFadeGroup (this, Property.State.Expanded))
+            {
+                for (var i = 0; i < Property.Children.Count; i += 1)
+                {
+                    Property.Children[i].Draw ();
+                }
+            }
+            SirenixEditorGUI.EndFadeGroup ();
             GUILayout.EndVertical ();
         }
     }

--- a/Assets/Content/Code/Area/Editor/AreaScene.cs
+++ b/Assets/Content/Code/Area/Editor/AreaScene.cs
@@ -33,10 +33,20 @@ namespace Area.Scene
     enum PropEditCommand
     {
         None = 0,
+        Snap,
         RotateLeft,
+        RotateRight,
         Flip,
+        ResetRotation,
+        Offset,
+        CopyPosition,
+        PastePosition,
+        ResetPosition,
+        ChangeColor,
         CopyColor,
         PasteColor,
+        ResetColor,
+        ChangeSelected,
         DeleteSelected,
     }
 

--- a/Assets/Content/Code/Area/Editor/AreaSceneBlackboard.cs
+++ b/Assets/Content/Code/Area/Editor/AreaSceneBlackboard.cs
@@ -65,7 +65,10 @@ namespace Area
         public readonly PropEditInfo propEditInfo = new PropEditInfo ();
         public PropEditingMode propEditingMode = PropEditingMode.Place;
         public readonly ClipboardPropColor clipboardPropColor = new ClipboardPropColor();
+        public (float X, float Z) propOffset;
+        public (Vector4 Primary, Vector4 Secondary) propColor;
         public PropEditCommand propEditCommand;
+        public PropEditFunctions propEditFunctions;
 
         public bool hoverActive;
         public AreaVolumePoint lastPointHovered;

--- a/Assets/Content/Code/Area/Editor/AreaSceneModePanels/AreaSceneModePanelHelper.cs
+++ b/Assets/Content/Code/Area/Editor/AreaSceneModePanels/AreaSceneModePanelHelper.cs
@@ -442,6 +442,7 @@ namespace Area
         public string Z;
     }
 
+    [AttributeUsage (AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class MiniSliderAttribute : Attribute
     {
         public readonly string MinGetter;
@@ -478,5 +479,17 @@ namespace Area
     public sealed class BoxWithBackgroundGroupAttribute : PropertyGroupAttribute
     {
         public BoxWithBackgroundGroupAttribute(string path) : base(path) { }
+    }
+
+    [AttributeUsage (AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
+    public sealed class RightFoldoutGroupAttribute : PropertyGroupAttribute
+    {
+        public readonly string Title;
+
+        public RightFoldoutGroupAttribute (string path, string title)
+            : base (path)
+        {
+            Title = title;
+        }
     }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
The hand-rolled IMGUI logic in the prop panel draw method is replaced with classes that use Odin attributes. The editing logic is now consolidated in the mode class.

In-scene rotation via keyboard bindings was broken in an earlier refactor and there were a few corner cases where the prop list in the panel could shrink and then cause layout errors. Both bugs are fixed.


### Related Issues
- Resolves #003
<!-- List any other related issues here -->

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
