### PR TITLE
Hide open tutorial button on start page when assets are installed

### DIFF
--- a/Assets/Content/Code/ModTools/Editor/ModToolsWindowData.cs
+++ b/Assets/Content/Code/ModTools/Editor/ModToolsWindowData.cs
@@ -140,19 +140,19 @@ namespace PhantomBrigade.ModTools
                     var completed = IsSectionCompleted (section);
                     var prevEnabled = GUI.enabled;
                     GUI.enabled = enabled;
-                    
+
                     Texture2D image = null;
                     if (!string.IsNullOrEmpty (section.image))
                         image = ModToolsTextureHelper.GetTexture (section.image);
-                    
+
                     var hasActionBtns = section.buttons != null;
                     var actionBtnsHeight = hasActionBtns ? 25 : 0;
                     var difficultyRectWidth = 30;
                     var predicted = prevWidth - textPadding - textPadding - iconWidth - difficultyRectWidth;
                     var descriptionSize = string.IsNullOrEmpty (section.description) ? 0 : multiline.CalcHeight (GUIHelper.TempContent (section.description), predicted);
-                    
+
                     var imageHeightLimit = 512; // Take from field
-                    
+
                     float imageWidth = 0f;
                     float imageHeight = 0f;
 
@@ -162,23 +162,23 @@ namespace PhantomBrigade.ModTools
                         // imageWidth = Mathf.Min (image.width, Mathf.Min (contentWidth, imageHeight));
                         // var shrink = imageWidth / Mathf.Max (2f, image.width);
                         // imageHeight = Mathf.Max (2f,  image.height) * shrink;
-                        
+
                         imageHeightLimit = Mathf.Clamp (imageHeightLimit, 16, 512);
                         imageWidth = Mathf.Min (GUIHelper.ContextWidth - 100f, image.width);
                         var shrink = imageWidth / (float) image.width;
                         imageHeight = image.height * shrink;
                     }
-                    
+
                     var rectHeight = 50 + descriptionSize + actionBtnsHeight + imageHeight;
                     var rect = GUILayoutUtility.GetRect (0, rectHeight * this.VerticalSlideT);
-                    
+
                     var bgRect = rect;
                     var iconRect = rect.TakeFromLeft (iconWidth).AlignCenterY (25 * this.VerticalSlideT);
                     var contentRect = rect.Padding (textPadding);
-        
+
                     var imageRect = contentRect.TakeFromTop (imageHeight);
                     imageRect = imageRect.TakeFromLeft (imageWidth);
-                    
+
                     var titleRect = contentRect.TakeFromTop (20);
                     var difficultyRect = contentRect.TakeFromRight (difficultyRectWidth).AlignBottom (EditorGUIUtility.singleLineHeight);
                     var descriptionRect = contentRect;
@@ -272,7 +272,7 @@ namespace PhantomBrigade.ModTools
                             }
                         }
                     }
-                    
+
 
                     if (i != this.sections.Count - 1)
                     {
@@ -525,9 +525,13 @@ namespace PhantomBrigade.ModTools
                         funcCheck = AssetsInstalled,
                         buttons = new List<DataBlockModToolsButton> ()
                         {
-                            new DataBlockModToolsButton
+                            new DataBlockModToolsButtonConditional
                             {
                                 label = "Open tutorial",
+                                conditions = new List<IModToolsCheck>
+                                {
+                                    new ModToolsCheckAssetPackage { required = false, },
+                                },
                                 actionsOnClick = new List<IModToolsFunction>
                                 {
                                     new ModToolsFunctionOpenTutorial (),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
The button to open the tutorial for installing the optional asset package is hidden after the package has been installed. That makes it clearer the task is completed.

### Related Issues
- Resolves #007

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
