### PR TITLE
Add a component for library DLL files

### DIFF
--- a/Assets/Content/Code/ModTools/ModToolsHelper.cs
+++ b/Assets/Content/Code/ModTools/ModToolsHelper.cs
@@ -84,7 +84,7 @@ namespace PhantomBrigade.SDK.ModTools
                 {
                     var idOther = kvp.Key;
                     var modOther = kvp.Value;
- 
+
                     // If this request originates from a registered mod, skip comparison to that mod
                     if (modSource != null && modSource == modOther)
                         continue;
@@ -96,7 +96,7 @@ namespace PhantomBrigade.SDK.ModTools
                     }
                 }
             }
-            
+
             errorDesc = "";
             return true;
         }
@@ -664,10 +664,11 @@ namespace PhantomBrigade.SDK.ModTools
                 Debug.Log ($"Can't generate mod files: mod data is null");
                 return;
             }
-            
+
             modData.DeleteOutputDirectories ();
 
             GenerateAssetBundles (modData);
+            GenerateLibraries (modData);
             var (ok, uds) = CanGenerateConfigOverrides (modData);
             if (!ok)
             {
@@ -687,7 +688,7 @@ namespace PhantomBrigade.SDK.ModTools
         {
             if (modData?.configEdits == null)
                 return;
-            
+
             modData.configEdits.SaveToMod (modData);
         }
 
@@ -713,6 +714,51 @@ namespace PhantomBrigade.SDK.ModTools
 
             Debug.Log ($"Building asset bundles:\n- Temp folder:{buildPathTemp}\n- Final folder: {buildPathFinal}");
             ModToolsAssetBundles.BuildAllAssetBundlesFromList (buildPathTemp, modData.assetBundles.bundleDefinitions, buildPathFinal);
+        }
+
+        static void GenerateLibraries (DataContainerModData modData)
+        {
+            if (modData == null)
+            {
+                return;
+            }
+
+            if (modData.metadata == null)
+            {
+                return;
+            }
+            if (!modData.metadata.includesLibraries)
+            {
+                return;
+            }
+            if (modData.libraryDLLs == null)
+            {
+                return;
+            }
+            if (modData.libraryDLLs.files.Count == 0)
+            {
+                return;
+            }
+
+            var pathLibraries = DataPathHelper.GetCombinedCleanPath (modData.GetModPathProject (), DataContainerModData.librariesFolderName);
+            if (!Directory.Exists (pathLibraries))
+            {
+                Directory.CreateDirectory (pathLibraries);
+            }
+            foreach (var dll in modData.libraryDLLs.files)
+            {
+                if (!dll.enabled)
+                {
+                    continue;
+                }
+                if (!File.Exists (dll.path))
+                {
+                    continue;
+                }
+
+                var pathDest = DataPathHelper.GetCombinedCleanPath (pathLibraries, Path.GetFileName (dll.path));
+                File.Copy (dll.path, pathDest, true);
+            }
         }
 
         static (bool, UtilityDatabaseSerialization) CanGenerateConfigOverrides (DataContainerModData modData)

--- a/Assets/Content/Code/ModTools/ModToolsHelper.cs
+++ b/Assets/Content/Code/ModTools/ModToolsHelper.cs
@@ -43,14 +43,14 @@ namespace PhantomBrigade.SDK.ModTools
         public static bool IsUnityVersionSupported (bool strict = true)
         {
             var unityVersion = Application.unityVersion;
-            bool match = 
-                strict ? 
-                string.Equals (unityVersion, unityVersionExpected, StringComparison.Ordinal) : 
+            bool match =
+                strict ?
+                string.Equals (unityVersion, unityVersionExpected, StringComparison.Ordinal) :
                 unityVersion.Contains (unityVersionExpectedMajor, StringComparison.Ordinal);
 
             return match;
         }
-        
+
         public static bool ValidateModID (string id, DataContainerModData modSource, IDictionary<string, DataContainerModData> mods, out string errorDesc)
         {
             if (string.IsNullOrWhiteSpace (id))
@@ -668,7 +668,9 @@ namespace PhantomBrigade.SDK.ModTools
             modData.DeleteOutputDirectories ();
 
             GenerateAssetBundles (modData);
+            #if UNITY_EDITOR
             GenerateLibraries (modData);
+            #endif
             var (ok, uds) = CanGenerateConfigOverrides (modData);
             if (!ok)
             {
@@ -716,6 +718,7 @@ namespace PhantomBrigade.SDK.ModTools
             ModToolsAssetBundles.BuildAllAssetBundlesFromList (buildPathTemp, modData.assetBundles.bundleDefinitions, buildPathFinal);
         }
 
+        #if UNITY_EDITOR
         static void GenerateLibraries (DataContainerModData modData)
         {
             if (modData == null)
@@ -760,6 +763,7 @@ namespace PhantomBrigade.SDK.ModTools
                 File.Copy (dll.path, pathDest, true);
             }
         }
+        #endif
 
         static (bool, UtilityDatabaseSerialization) CanGenerateConfigOverrides (DataContainerModData modData)
         {

--- a/Assets/Content/Code/Mods/ModData.cs
+++ b/Assets/Content/Code/Mods/ModData.cs
@@ -37,7 +37,7 @@ namespace PhantomBrigade.Mods
 
         [LabelText ("Copy version text")]
         public bool textFromMetadataVersion = true;
-        
+
         [LabelText ("Copy main text")]
         public bool textFromMetadataMain = true;
 
@@ -53,17 +53,17 @@ namespace PhantomBrigade.Mods
         // [FoldoutGroup ("Internal data", false)]
         // [HideLabel, TextArea (1, 10)]
         public string internalData;
-        
+
         [TextArea (1, 10)]
         public string changes;
-        
+
         #if PB_MODSDK && UNITY_EDITOR
         List<string> workshopTags => SteamWorkshopHelper.tags;
         [ValueDropdown ("@" + nameof(workshopTags))]
         #endif
 
         public HashSet<string> tags = new HashSet<string> ();
-        
+
         // Optional texture preview. Automatically generated texture based on a PNG file
         // placed next to the mod folder under ModFiles/. Not hosted within mod folders
         // because this image should not be included into Steam Workshop mod content uploads
@@ -76,10 +76,10 @@ namespace PhantomBrigade.Mods
         // each redraw doesn't retrigger creation of a new texture
         [YamlIgnore]
         private bool texLoadAttempt;
-        
+
         [YamlIgnore]
         public const string texFilename = "workshop_preview.png";
-        
+
         #if UNITY_EDITOR
 
         [YamlIgnore, HideInInspector]
@@ -140,12 +140,12 @@ namespace PhantomBrigade.Mods
                 }
             }
         }
-        
+
         void RefreshTexturePreview ()
         {
             texLoadAttempt = true;
             texPreview = null;
-            
+
             if (parent == null)
                 return;
 
@@ -166,7 +166,7 @@ namespace PhantomBrigade.Mods
                 filterMode = FilterMode.Bilinear,
                 anisoLevel = 2,
             };
-            
+
             texPreview.LoadImage (pngBytes);
         }
 
@@ -189,11 +189,11 @@ namespace PhantomBrigade.Mods
 
         [PropertyOrder (-2)]
         public int priority;
-        
+
         [ShowInInspector, HorizontalGroup]
         [PropertyRange (0f, 1f)]
         public float colorHue = 0.5f;
-        
+
         [ShowInInspector, HorizontalGroup (50f), HideLabel]
         public Color color => Color.HSVToRGB (colorHue, 1f, 1f);
 
@@ -205,7 +205,7 @@ namespace PhantomBrigade.Mods
 
         [LabelText ("Version")]
         public string ver;
-        
+
         [LabelText ("Web page URL")]
         public string url;
 
@@ -213,18 +213,20 @@ namespace PhantomBrigade.Mods
         [EnableIf (nameof(isConfigEnabled))]
         #endif
         public bool includesConfigOverrides;
-        
+
         [ReadOnly, PropertyTooltip ("Add config edits via the bottom right component menu to enable this flag")]
         public bool includesConfigEdits;
 
         [HideInInspector] // Currently unused
         public bool includesConfigTrees;
 
+        [ReadOnly, PropertyTooltip ("Add library DLLs via the bottom right component menu to enable this flag")]
         public bool includesLibraries;
+
         public bool includesTextures;
         public bool includesLocalizationEdits;
         public bool includesLocalizations;
-        
+
         [ReadOnly, PropertyTooltip ("Add asset bundles via the bottom right component menu to enable this flag")]
         public bool includesAssetBundles;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
Add a section to the mod inspector for library DLLs. Multiple DLL files can be listed and they can be sourced from paths outside the mod project folder.

This follows the same pattern as config edits and asset bundles. The component shows up in the dropdown in the bottom right and the metadata includeLibraries field is toggled depending on if the component is not null.

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
