### PR TITLE
Skip null point when drawing spawn/waypoints

### DIFF
--- a/Assets/Content/Code/Data/Editor/DataMultiLinkerCombatAreaInspector.cs
+++ b/Assets/Content/Code/Data/Editor/DataMultiLinkerCombatAreaInspector.cs
@@ -1442,6 +1442,17 @@ abstract class PointGroupDrawer
         for (var i = 0; i < points.Count; ++i)
         {
             var point = points[i];
+            #if !PB_MODSDK
+            if (point == null)
+            {
+                // It is possible the points collection has a null point. This is because the default value for DataBlockAreaPoint is null and
+                // the ListDrawerSettings attribute on a points collection has AlwaysAddDefaultValue = true. So if the user adds a new point to
+                // the collection through the inspector, the null will be seen on every update until the user selects DataBlockAreaPoint from
+                // the object picker for the new entry in the points collection.
+                continue;
+            }
+            #endif
+
             var position = point.point;
             var rotation = Quaternion.Euler (point.rotation);
             var forward = rotation * Vector3.forward;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
This prevents a NullReferenceException from being thrown on every update when a new spawn point or waypoint is added to a combat area through the add button on the lists in the inspector. Before this change, the add button would add a null to the list. Now it will add either a copy of the last point in the list offset vertically or a new object with default values if there are no existing points in the list.

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
