### PR TITLE
Show bottom cubes on volumes

### DIFF
--- a/Assets/Content/Code/Data/Editor/DataMultiLinkerCombatAreaInspector.cs
+++ b/Assets/Content/Code/Data/Editor/DataMultiLinkerCombatAreaInspector.cs
@@ -974,6 +974,15 @@ public class DataMultiLinkerCombatAreaInspector : OdinEditor
         if (distMax <= 0f || distMax - distMin <= 0f)
             fadeUsed = false;
 
+        #if PB_MODSDK
+        if (list.Count < 3)
+        {
+            // No sense in fading a 2-block structure. One of the blocks will be at max dist and
+            // therefore be invisible (alpha = 0).
+            fadeUsed = false;
+        }
+        #endif
+
         var distSpan = distMax - distMin;
 
         list.Sort ((a, b) => b.dist.CompareTo (a.dist));
@@ -990,7 +999,12 @@ public class DataMultiLinkerCombatAreaInspector : OdinEditor
             if (fadeUsed)
             {
                 var interpolant = Mathf.Clamp01 ((cubeDesc.dist - distMin) / distSpan);
+                #if PB_MODSDK
+                // Don't fade out the farthest block completely. Otherwise, for some structures it will look like the farthest block is missing.
+                var fade = Mathf.Lerp (1f, 0.125f, interpolant);
+                #else
                 var fade = Mathf.Lerp (1f, 0f, interpolant);
+                #endif
                 Handles.color = cubeDesc.color.WithAlpha (fade);
             }
             else


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
The fading on volume cubes can make it look like there's a bug because the bottom cubes are invisible (alpha is zero). The bottom cubes should still be visible to help visualize the entire structure.

### Related Issues
- Resolves #001 *(insert related issue ID here)*
<!-- List any other related issues here -->

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
