### PR TITLE
Remove incorrect namespace on entity classes

### DIFF
--- a/Assets/Content/Code/CombatOverhaul/Production/Functions/EntityClassPlaceholders.cs
+++ b/Assets/Content/Code/CombatOverhaul/Production/Functions/EntityClassPlaceholders.cs
@@ -1,17 +1,9 @@
-namespace PhantomBrigade
-{
-    public class PersistentEntity { }
-    
-    public class OverworldEntity { }
-    
-    public class OverworldActionEntity { }
-    
-    public class CombatEntity { }
-
-    public class ActionEntity { }
-
-    public class EquipmentEntity { }
-}
+public class PersistentEntity { }
+public class OverworldEntity { }
+public class OverworldActionEntity { }
+public class CombatEntity { }
+public class ActionEntity { }
+public class EquipmentEntity { }
 
 namespace PhantomBrigade.Game
 {
@@ -76,14 +68,14 @@ public enum CombatUIModes
 
 public class StartEndModifier
 {
-    public enum Exactness 
+    public enum Exactness
     {
-		SnapToNode,
-		Original,
-		Interpolate,
-		ClosestOnNode,
-		NodeConnection
-	}
+        SnapToNode,
+        Original,
+        Interpolate,
+        ClosestOnNode,
+        NodeConnection
+    }
 }
 
 public enum UnitStatusSource
@@ -107,7 +99,7 @@ public class PilotIdentification
 {
     public int callsignIndex;
     public string callsignOverride;
-        
+
     public int nameIndexPrimary;
     public int nameIndexSecondary;
     public string nameOverride;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
Modders should be able to provide their own implementations of function interface classes. Many of the function interfaces take entity classes as parameters but by being in a namespace for the SDK when the same classes are at the top level in the game assemblies makes life more difficult for modders.

### Related Issues
- Resolves #001 *(insert related issue ID here)*
<!-- List any other related issues here -->

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
