### PR TITLE
Enable/disable colliders to match point state when leaving layer mode

### DIFF
--- a/Assets/Content/Code/Area/Editor/AreaSceneModes/AreaSceneLayerMode.cs
+++ b/Assets/Content/Code/Area/Editor/AreaSceneModes/AreaSceneLayerMode.cs
@@ -257,6 +257,10 @@ namespace Area
             var am = bb.am;
             foreach (var point in am.points)
             {
+                if (point.pointState == AreaVolumePointState.Empty)
+                {
+                    continue;
+                }
                 if (point.instanceCollider == null)
                 {
                     continue;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
Entering layer mode disables all the individual point colliders and enables a different collider to allow hit testing on parts of the map that aren't normally accessible (e.g., empty space). Point state can be toggled in layer mode but when the mode exists, it enables colliders on every point that has a non-null collider. Instead, it should sync up the individual point colliders with the changes made to point state.

### Related Issues
- Resolves #001 *(insert related issue ID here)*
<!-- List any other related issues here -->

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
