### PR TITLE
Fix failed type lookup

### DIFF
--- a/Assets/Content/Code/Data/DataLinker.cs
+++ b/Assets/Content/Code/Data/DataLinker.cs
@@ -156,8 +156,8 @@ namespace PhantomBrigade.Data
             }
             else
             {
-                var sdkPath = Path.Combine (DataPathHelper.GetApplicationFolder (), "Configs", pair.SDK.RelativePath);
-                var modPath = Path.Combine (configsPath, pair.Mod.RelativePath);
+                var sdkPath = DataPathHelper.GetCombinedCleanPath (DataPathHelper.GetApplicationFolder (), "Configs", pair.SDK.RelativePath);
+                var modPath = DataPathHelper.GetCombinedCleanPath (configsPath, pair.Mod.RelativePath);
                 File.Copy (sdkPath, modPath, true);
                 LoadData ();
             }

--- a/Assets/Content/Code/Data/DataMultiLinker.cs
+++ b/Assets/Content/Code/Data/DataMultiLinker.cs
@@ -48,7 +48,7 @@ namespace PhantomBrigade.Data
             var col = Color.HSVToRGB (Mathf.Abs (hueStart - (float)index / 12f) % 1f, 0.25f, b).WithAlpha (alpha);
             return col;
         }
-        
+
         public static Color GetColorFromElementIndexBright (int index, float hueStart = 0.6f, float saturation = 0.25f)
         {
             var col = Color.HSVToRGB (Mathf.Abs (hueStart - (float)index / 12f) % 1f, saturation, 1f).WithAlpha (1f);
@@ -479,7 +479,7 @@ namespace PhantomBrigade.Data
         private Color GetColor () =>
             Color.HSVToRGB (collision ? 0f : 0.55f, 0.5f, 1f);
     }
-    
+
     [HideReferenceObjectPicker, DisableContextMenu]
     public class DataFilterKeyValuePair<T> where T : DataContainer, new()
     {
@@ -519,7 +519,7 @@ namespace PhantomBrigade.Data
             }
             parent.DeleteEntry (key);
         }
-        
+
         #endif
 
         [VerticalGroup ("value", Order = 2)]
@@ -566,7 +566,7 @@ namespace PhantomBrigade.Data
             parent.ReplaceKey (keyLast, key);
             keyLast = key;
         }
-        
+
         #endif
     }
 
@@ -857,8 +857,8 @@ namespace PhantomBrigade.Data
             }
             else
             {
-                var sdkPath = Path.Combine (DataPathHelper.GetApplicationFolder (), "Configs", pair.SDK.RelativePath);
-                var modPath = Path.Combine (configsPath, pair.Mod.RelativePath);
+                var sdkPath = DataPathHelper.GetCombinedCleanPath (DataPathHelper.GetApplicationFolder (), "Configs", pair.SDK.RelativePath);
+                var modPath = DataPathHelper.GetCombinedCleanPath (configsPath, pair.Mod.RelativePath);
                 Directory.Delete (modPath, true);
                 Directory.CreateDirectory (modPath);
                 ModToolsHelper.CopyConfigDB (new DirectoryInfo (sdkPath), modPath);
@@ -908,7 +908,7 @@ namespace PhantomBrigade.Data
         [FoldoutGroup (OdinGroup.Name.Settings)]
         [OnInspectorGUI ("AppendedInspectorGUI")]
         public bool log = false;
-        
+
         [ShowInInspector]
         [FoldoutGroup (OdinGroup.Name.Settings)]
         [ShowIf (nameof(IsDisplayIsolated))]
@@ -1113,7 +1113,7 @@ namespace PhantomBrigade.Data
         {
             #if UNITY_EDITOR
             UnityEditor.EditorApplication.update -= UpdateInEditor;
-            
+
             filterRequested = false;
             filterRequestedFromLoad = false;
             #endif
@@ -1406,8 +1406,8 @@ namespace PhantomBrigade.Data
             dataInternal.Add (keyNew, entry);
             if (IsUsingDirectories ())
             {
-                var pathOld = Path.Combine (pathLocal, keyOld);
-                var pathNew = Path.Combine (pathLocal, keyNew);
+                var pathOld = DataPathHelper.GetCombinedCleanPath (pathLocal, keyOld);
+                var pathNew = DataPathHelper.GetCombinedCleanPath (pathLocal, keyNew);
                 Directory.Move (pathOld, pathNew);
                 #if PB_MODSDK
                 LoadDataIsolated (keyNew);
@@ -1563,7 +1563,7 @@ namespace PhantomBrigade.Data
         {
             if (data == null)
                 return null;
-            
+
             return data.Keys;
         }
 
@@ -1879,7 +1879,7 @@ namespace PhantomBrigade.Data
             #if PB_MODSDK
 
             ModTextHelper.GenerateTextChangesToSectors (textSectorKeys);
-            
+
             #endif
         }
 
@@ -1950,8 +1950,8 @@ namespace PhantomBrigade.Data
 
             if (IsUsingDirectories ())
             {
-                var sourcePath = Path.Combine (pathLocal, key);
-                var destPath = Path.Combine (pathLocal, keyNew);
+                var sourcePath = DataPathHelper.GetCombinedCleanPath (pathLocal, key);
+                var destPath = DataPathHelper.GetCombinedCleanPath (pathLocal, keyNew);
                 CopyDirectoryContents (new DirectoryInfo (sourcePath), destPath);
                 LoadDataIsolated (keyNew);
             }
@@ -1995,7 +1995,7 @@ namespace PhantomBrigade.Data
                     return;
                 }
 
-                var folderPath = Path.Combine (pathLocal, key);
+                var folderPath = DataPathHelper.GetCombinedCleanPath (pathLocal, key);
                 Directory.Delete (folderPath, true);
             }
             dataInternal.Remove (key);
@@ -2016,12 +2016,12 @@ namespace PhantomBrigade.Data
             Directory.CreateDirectory (dest);
             foreach (var f in source.EnumerateFiles ())
             {
-                var destPath = Path.Combine (dest, f.Name);
+                var destPath = DataPathHelper.GetCombinedCleanPath (dest, f.Name);
                 f.CopyTo (destPath);
             }
             foreach (var d in source.EnumerateDirectories ())
             {
-                var destPath = Path.Combine (dest, d.Name);
+                var destPath = DataPathHelper.GetCombinedCleanPath (dest, d.Name);
                 CopyDirectoryContents (d, destPath);
             }
         }
@@ -2076,7 +2076,7 @@ namespace PhantomBrigade.Data
                 foreach (var key in dataInternal.Keys)
                 {
                     var fileName = key + ".yaml";
-                    var filePath = Path.Combine (path, fileName);
+                    var filePath = DataPathHelper.GetCombinedCleanPath (path, fileName);
                     try
                     {
                         entries.Add ((fileName, File.ReadAllText (filePath)));
@@ -2148,7 +2148,7 @@ namespace PhantomBrigade.Data
         {
             if (!IsModdableStatic ())
                 return;
-            
+
             UpdateChecksums ();
             ModToolsHelper.SaveChecksums (DataContainerModData.selectedMod);
         }

--- a/Assets/Content/Code/ModTools/ConfigChecksums.cs
+++ b/Assets/Content/Code/ModTools/ConfigChecksums.cs
@@ -18,11 +18,11 @@ namespace PhantomBrigade.SDK.ModTools
 
         public static bool logPathResolution = false;
 
-        public static bool ChecksumsExist (DirectoryInfo source) => File.Exists (Path.Combine (source.FullName, checksumsFileName));
+        public static bool ChecksumsExist (DirectoryInfo source) => File.Exists (DataPathHelper.GetCombinedCleanPath (source.FullName, checksumsFileName));
         public static bool CopyChecksumsFile (DirectoryInfo source, DirectoryInfo dest)
         {
-            var checksumsPath = Path.Combine (source.FullName, checksumsFileName);
-            var destPath = Path.Combine (dest.FullName, checksumsFileName);
+            var checksumsPath = DataPathHelper.GetCombinedCleanPath (source.FullName, checksumsFileName);
+            var destPath = DataPathHelper.GetCombinedCleanPath (dest.FullName, checksumsFileName);
             try
             {
                 File.Copy (checksumsPath, destPath, true);
@@ -190,8 +190,8 @@ namespace PhantomBrigade.SDK.ModTools
             {
                 current = root;
                 ComputeDirectoryChecksums (root);
-                var pathChecksums = Path.Combine (sourceDirectory.Parent.FullName, checksumsFileName);
-                var fi = new FileInfo (Path.Combine (pathChecksums + ".tmp"));
+                var pathChecksums = DataPathHelper.GetCombinedCleanPath (sourceDirectory.Parent.FullName, checksumsFileName);
+                var fi = new FileInfo (DataPathHelper.GetCombinedCleanPath (pathChecksums + ".tmp"));
                 using (var outp = new BinaryWriter (fi.OpenWrite ()))
                 {
                     directoryQueue.Clear ();
@@ -324,7 +324,7 @@ namespace PhantomBrigade.SDK.ModTools
         {
             public Deserializer (DirectoryInfo rootDirectory)
             {
-                checksumsFile = new FileInfo (Path.Combine (rootDirectory.FullName, checksumsFileName));
+                checksumsFile = new FileInfo (DataPathHelper.GetCombinedCleanPath (rootDirectory.FullName, checksumsFileName));
             }
 
             public Result Load ()
@@ -501,7 +501,7 @@ namespace PhantomBrigade.SDK.ModTools
                             HalfSum1 = cksum0,
                             HalfSum2 = cksum1,
                         },
-                        RelativePath = Encoding.UTF8.GetString (rawPath),
+                        RelativePath = DataPathHelper.GetCleanPath (Encoding.UTF8.GetString (rawPath)),
                         Locator = locator.Select(v => (int)v).ToArray(),
                     };
                     var dirCount = inp.ReadUInt16 ();
@@ -512,7 +512,7 @@ namespace PhantomBrigade.SDK.ModTools
 
                     if (entry.RelativePath.StartsWith (DataDecomposedDirectoryName))
                     {
-                        var cleanedPath = DataPathHelper.GetCleanPath (entry.RelativePath) + "/";
+                        var cleanedPath = entry.RelativePath + "/";
                         var typeName = DataPathUtility.GetDataTypeFromPath (cleanedPath, fallbackAllowed: false);
                         if (typeName != null)
                         {
@@ -583,7 +583,7 @@ namespace PhantomBrigade.SDK.ModTools
                             HalfSum1 = cksum0,
                             HalfSum2 = cksum1,
                         },
-                        RelativePath = Encoding.UTF8.GetString (rawPath),
+                        RelativePath = DataPathHelper.GetCleanPath (Encoding.UTF8.GetString (rawPath)),
                         Locator = locator.ToArray(),
                     };
                     entries.Add (entry);
@@ -591,9 +591,9 @@ namespace PhantomBrigade.SDK.ModTools
                     var ext = Path.GetExtension (entry.RelativePath);
                     if (!entry.RelativePath.StartsWith (DataDecomposedDirectoryName) && ext == ".yaml")
                     {
-                        var cleanedPath = DataPathHelper.GetCleanPath (entry.RelativePath);
+                        var cleanedPath = entry.RelativePath;
                         cleanedPath = cleanedPath.Substring (0, cleanedPath.Length - ext.Length);
-                        var typeName = DataPathUtility.GetDataTypeFromPath (cleanedPath);
+                        var typeName = DataPathUtility.GetDataTypeFromPath (cleanedPath, fallbackAllowed: false);
                         if (typeName != null)
                         {
                             var t = FieldReflectionUtility.GetTypeByName (typeName);
@@ -733,7 +733,7 @@ namespace PhantomBrigade.SDK.ModTools
                 for (var i = 0; i < newEntries.Count; i += 1)
                 {
                     var entry = newEntries[i];
-                    var subdirectory = new DirectoryInfo (Path.Combine (root.FullName, entry.RelativePath));
+                    var subdirectory = new DirectoryInfo (DataPathHelper.GetCombinedCleanPath (root.FullName, entry.RelativePath));
                     try
                     {
                         AddRecursive (root, source, entry, subdirectory);
@@ -820,7 +820,7 @@ namespace PhantomBrigade.SDK.ModTools
                 }
                 foreach (var entry in newEntries)
                 {
-                    var subdirectory = new DirectoryInfo (Path.Combine (root.FullName, entry.RelativePath));
+                    var subdirectory = new DirectoryInfo (DataPathHelper.GetCombinedCleanPath (root.FullName, entry.RelativePath));
                     if (!subdirectory.Exists)
                     {
                         continue;

--- a/Assets/Content/Code/ModTools/DataContainerModData.cs
+++ b/Assets/Content/Code/ModTools/DataContainerModData.cs
@@ -669,17 +669,17 @@ namespace PhantomBrigade.SDK.ModTools
 
         public void DeleteOutputDirectories ()
         {
-            var configOverridesPath = Path.Combine (GetModPathProject (), overridesFolderName);
+            var configOverridesPath = DataPathHelper.GetCombinedCleanPath (GetModPathProject (), overridesFolderName);
             if (Directory.Exists (configOverridesPath))
             {
                 Directory.Delete (configOverridesPath, true);
             }
-            var configEditsPath = Path.Combine (GetModPathProject (), editsFolderName);
+            var configEditsPath = DataPathHelper.GetCombinedCleanPath (GetModPathProject (), editsFolderName);
             if (Directory.Exists (configEditsPath))
             {
                 Directory.Delete (configEditsPath, true);
             }
-            var assetBundlesPath = Path.Combine (GetModPathProject (), assetBundlesFolderName);
+            var assetBundlesPath = DataPathHelper.GetCombinedCleanPath (GetModPathProject (), assetBundlesFolderName);
             if (Directory.Exists (assetBundlesPath))
             {
                 Directory.Delete (assetBundlesPath, true);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, please read our contributor guidelines: https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md -->

### Description
The API to get a type from a path changed to allow partial lookups by default. In the original update to 2.0, I had corrected one place where I was using it but missed a second.

Some file APIs in Mono also choke on paths with mixed separators. All path arguments to file operations in the checksum logic are canonicalized with the clean path API.

### Related Issues

### Checklist

- [x] I have tested the SDK with this change in place and identified no regressions
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license. 
- [x] My commit description includes <Signed-off-by> line confirming my agreement to the Developer Certificate of Origin.

*For more information on signing off your commits, please check [here](https://github.com/BraceYourselfGames/PB_ModSDK/blob/main/CONTRIBUTING.md#contributing-code).*
